### PR TITLE
Align FlightGear visual scenery with PX4 Location

### DIFF
--- a/scene/LSZH.xml
+++ b/scene/LSZH.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<initialize name="Startup in San Fran">
-  <latitude unit="DEG"> 47.458159 </latitude>
+<initialize name="Zurich">
+  <latitude type="geodetic" unit="DEG"> 47.458159 </latitude>
   <longitude unit="DEG"> 8.548004 </longitude>
   <altitude unit="M"> 0.5 </altitude>
   <elevation unit="M"> 419.2 </elevation>

--- a/src/sensor_gps_plugin.cpp
+++ b/src/sensor_gps_plugin.cpp
@@ -61,7 +61,7 @@ SensorData::Gps SensorGpsPlugin::getGpsFromJSBSim() {
   SensorData::Gps ret;
   ret.time_utc_usec = _sim_ptr->GetSimTime() * 1e6;
   ret.fix_type = 3;
-  ret.latitude_deg = _sim_ptr->GetPropertyValue("position/lat-gc-deg") * 1e7;
+  ret.latitude_deg = _sim_ptr->GetPropertyValue("position/lat-geod-deg") * 1e7;
   ret.longitude_deg = _sim_ptr->GetPropertyValue("position/long-gc-deg") * 1e7;
   ret.altitude = _sim_ptr->GetPropertyValue("position/h-sl-meters") * 1e7;
   ret.eph = 1 * 100;


### PR DESCRIPTION
This modification resolves a conflict between FlightGear and PX4 geocentric vs geodetic latitude that creates a mismatch in visual scenery representation. Also see: https://en.wikipedia.org/wiki/Geodetic_datum#Vertical_datum

<b>Prior to change (note the disagreement between QGC and FlightGear location representation):</b>
![Screenshot from 2020-09-18 07-30-18](https://user-images.githubusercontent.com/24363960/93597184-a528bb80-f988-11ea-8d96-2e754a48a5f4.png)

<b>After change (note the alignment between QGC and FlightGear location representation):</b>
![Screenshot from 2020-09-18 08-07-59](https://user-images.githubusercontent.com/24363960/93597274-c7223e00-f988-11ea-9055-2acdbc835a42.png)


