### PR TITLE
Improve sensor bias initialization and stability

### DIFF
--- a/include/sensor_imu_plugin.h
+++ b/include/sensor_imu_plugin.h
@@ -74,8 +74,6 @@ class SensorImuPlugin : public SensorPlugin {
   /// Norm of the gravitational acceleration [m/s^2]
   double gravity_magnitude;
 
-  Eigen::Vector3d _gyroscope_bias;
-  Eigen::Vector3d _accelerometer_bias;
 
   Eigen::Vector3d _gyroscope_turn_on_bias;
   Eigen::Vector3d _accelerometer_turn_on_bias;

--- a/include/sensor_mag_plugin.h
+++ b/include/sensor_mag_plugin.h
@@ -61,7 +61,5 @@ class SensorMagPlugin : public SensorPlugin {
   double _random_walk;
   double _bias_correlation_time;
 
-  Eigen::Vector3d _bias;
-
   double _last_sim_time;
 };

--- a/src/sensor_imu_plugin.cpp
+++ b/src/sensor_imu_plugin.cpp
@@ -41,6 +41,10 @@
 
 #include "sensor_imu_plugin.h"
 
+// Initialize sensor bias with zeros.
+std::vector<double> accelerometer_bias(3);
+std::vector<double> gyroscope_bias(3);
+
 // Default values for use with ADIS16448 IMU
 static constexpr double kDefaultAdisGyroscopeNoiseDensity = 2.0 * 35.0 / 3600.0 / 180.0 * M_PI;
 static constexpr double kDefaultAdisGyroscopeRandomWalk = 2.0 * 4.0 / 3600.0 / 180.0 * M_PI;
@@ -125,8 +129,8 @@ void SensorImuPlugin::addNoise(Eigen::Vector3d* linear_acceleration, Eigen::Vect
   double phi_g_d = exp(-1.0 / tau_g * dt);
   // Simulate gyroscope noise processes and add them to the true angular rate.
   for (int i = 0; i < 3; ++i) {
-    _gyroscope_bias[i] = phi_g_d * _gyroscope_bias[i] + sigma_b_g_d * _standard_normal_distribution(_random_generator);
-    (*angular_velocity)[i] = (*angular_velocity)[i] + _gyroscope_bias[i] +
+    gyroscope_bias[i] = phi_g_d * gyroscope_bias[i] + sigma_b_g_d * _standard_normal_distribution(_random_generator);
+    (*angular_velocity)[i] = (*angular_velocity)[i] + gyroscope_bias[i] +
                              sigma_g_d * _standard_normal_distribution(_random_generator) + _gyroscope_turn_on_bias[i];
   }
 
@@ -143,9 +147,9 @@ void SensorImuPlugin::addNoise(Eigen::Vector3d* linear_acceleration, Eigen::Vect
   // Simulate accelerometer noise processes and add them to the true linear
   // acceleration.
   for (int i = 0; i < 3; ++i) {
-    _accelerometer_bias[i] =
-        phi_a_d * _accelerometer_bias[i] + sigma_b_a_d * _standard_normal_distribution(_random_generator);
-    (*linear_acceleration)[i] = (*linear_acceleration)[i] + _accelerometer_bias[i] +
+    accelerometer_bias[i] =
+        phi_a_d * accelerometer_bias[i] + sigma_b_a_d *_standard_normal_distribution(_random_generator);
+    (*linear_acceleration)[i] = (*linear_acceleration)[i] + accelerometer_bias[i] +
                                 sigma_a_d * _standard_normal_distribution(_random_generator) +
                                 _accelerometer_turn_on_bias[i];
   }

--- a/src/sensor_mag_plugin.cpp
+++ b/src/sensor_mag_plugin.cpp
@@ -41,6 +41,9 @@
 
 #include "sensor_mag_plugin.h"
 
+// // Initialize sensor bias with zeros.
+std::vector<double> bias(3);
+
 static constexpr auto kDefaultPubRate = 100.0;  // [Hz]. Note: corresponds to most of the mag devices supported in PX4
 
 // Default values for use with ADIS16448 IMU
@@ -124,7 +127,7 @@ void SensorMagPlugin::addNoise(Eigen::Vector3d* magnetic_field, const double dt)
   double phi_d = exp(-1.0 / tau * dt);
   // Simulate magnetometer noise processes and add them to the true signal.
   for (int i = 0; i < 3; ++i) {
-    _bias[i] = phi_d * _bias[i] + sigma_b_d * _standard_normal_distribution(_random_generator);
-    (*magnetic_field)[i] = (*magnetic_field)[i] + _bias[i] + sigma_d * _standard_normal_distribution(_random_generator);
+    bias[i] = phi_d * bias[i] + sigma_b_d * _standard_normal_distribution(_random_generator);
+    (*magnetic_field)[i] = (*magnetic_field)[i] + bias[i] + sigma_d * _standard_normal_distribution(_random_generator);
   }
 }

--- a/src/sensor_mag_plugin.cpp
+++ b/src/sensor_mag_plugin.cpp
@@ -41,7 +41,7 @@
 
 #include "sensor_mag_plugin.h"
 
-// // Initialize sensor bias with zeros.
+// Initialize sensor bias with zeros.
 std::vector<double> bias(3);
 
 static constexpr auto kDefaultPubRate = 100.0;  // [Hz]. Note: corresponds to most of the mag devices supported in PX4


### PR DESCRIPTION
Observed instability in sensor bias initialization where PX4 reported values of mag, accel, and gyro sensor input were infinite or Nan on startup. Hypothesize that the way that the Eigen vectors were being initialized created a memory issue. Was unable to find an alternate using Eigen. 