### PR TITLE
Revise GPS publication handling

### DIFF
--- a/include/sensor_mag_plugin.h
+++ b/include/sensor_mag_plugin.h
@@ -62,6 +62,4 @@ class SensorMagPlugin : public SensorPlugin {
   double _bias_correlation_time;
 
   Eigen::Vector3d _bias;
-
-  double _last_sim_time;
 };

--- a/include/sensor_plugin.h
+++ b/include/sensor_plugin.h
@@ -52,6 +52,8 @@ class SensorPlugin {
   ~SensorPlugin();
   void setUpdateRate(double update_rate);
   bool updated();
+  bool updatedGPS();
+  double _last_gps_sim_time;
 
  protected:
   JSBSim::FGFDMExec *_sim_ptr;

--- a/src/jsbsim_bridge.cpp
+++ b/src/jsbsim_bridge.cpp
@@ -71,7 +71,9 @@ JSBSimBridge::JSBSimBridge(JSBSim::FGFDMExec *fdmexec, std::string &path)
 
   if (CheckConfigElement(config, "sensors", "gps")) {
     _gps_sensor = std::make_unique<SensorGpsPlugin>(_fdmexec);
-    _gps_sensor->setUpdateRate(1.0);
+    _gps_sensor->setUpdateRate(5.0);
+    //TODO read GPS update rate from XML
+    //TODO check less than 250Hz for lockstep
   }
 
   if (CheckConfigElement(config, "sensors", "barometer")) {
@@ -148,7 +150,7 @@ void JSBSimBridge::Run() {
   }
 
   // Send Mavlink HIL_GPS message
-  if (_gps_sensor && _gps_sensor->updated()) {
+  if (_gps_sensor && _gps_sensor->updatedGPS()) {
     _mavlink_interface->SendGpsMessages(_gps_sensor->getData());
   }
 

--- a/src/sensor_gps_plugin.cpp
+++ b/src/sensor_gps_plugin.cpp
@@ -41,19 +41,21 @@
 
 #include "sensor_gps_plugin.h"
 
-SensorGpsPlugin::SensorGpsPlugin(JSBSim::FGFDMExec *jsbsim) : SensorPlugin(jsbsim) { _update_rate = 1.0; }
+SensorGpsPlugin::SensorGpsPlugin(JSBSim::FGFDMExec *jsbsim) : SensorPlugin(jsbsim) { _update_rate = 5.0; }
+//TODO read update rate from XML
+//TODO check 250Hz for lockstep
 
 SensorGpsPlugin::~SensorGpsPlugin() {}
 
 SensorData::Gps SensorGpsPlugin::getData() {
-  double sim_time = _sim_ptr->GetSimTime();
-  double dt = sim_time - _last_sim_time;
+  double gps_sim_time = _sim_ptr->GetSimTime();
+  double gps_dt = gps_sim_time - _last_gps_sim_time;
 
   SensorData::Gps data;
 
   data = getGpsFromJSBSim();
 
-  _last_sim_time = sim_time;
+  _last_gps_sim_time = gps_sim_time;
   return data;
 }
 

--- a/src/sensor_plugin.cpp
+++ b/src/sensor_plugin.cpp
@@ -56,3 +56,13 @@ bool SensorPlugin::updated() {
   }
   return false;
 }
+
+bool SensorPlugin::updatedGPS() {
+  double gps_sim_time = _sim_ptr->GetSimTime();
+  double gps_dt = gps_sim_time - _last_gps_sim_time;
+
+  if (gps_dt > (1 / _update_rate) || _update_rate == 0) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Existing GPS publication has been observed to: not publish GPS data to PX4 at the expected frequency, or not publish it at all. Hypothesized and observed that the ** _last_sim_time** variable was being corrupted.  

Picture of GPS sensor update rate running at 5Hz with proposed changes. 

![Screenshot from 2020-09-27 21-27-34](https://user-images.githubusercontent.com/24363960/94381731-4ab9f880-0108-11eb-9fa6-5bcb1bcb647e.png)
