### PR TITLE
update Mavlink usage to match PX4

### DIFF
--- a/cmake/FindMAVLink.cmake
+++ b/cmake/FindMAVLink.cmake
@@ -5,11 +5,6 @@
 #  MAVLINK_INCLUDE_DIRS : include directories
 #  MAVLINK_VERSION      : version
 
-##
-# This file was compied form jsbsim_bridge submodule of PX4/Firmware
-##
-
-
 # macros
 include(FindPackageHandleStandardArgs)
 
@@ -25,6 +20,7 @@ set(_MAVLINK_EXTRA_SEARCH_HINTS
     ../../mavlink/
     ../mavlink/
     ${CATKIN_DEVEL_PREFIX}/
+    ${CMAKE_CURRENT_BINARY_DIR}/../mavlink/
     )
 
 set(_MAVLINK_EXTRA_SEARCH_PATHS
@@ -34,7 +30,7 @@ set(_MAVLINK_EXTRA_SEARCH_PATHS
 
 # look for in the hints first
 find_path(_MAVLINK_INCLUDE_DIR
-    NAMES mavlink/v1.0/mavlink_types.h mavlink/v2.0/mavlink_types.h
+    NAMES mavlink_types.h
     PATH_SUFFIXES include
     HINTS ${_MAVLINK_EXTRA_SEARCH_HINTS}
     NO_DEFAULT_PATH
@@ -42,8 +38,8 @@ find_path(_MAVLINK_INCLUDE_DIR
 
 # look for in the hard-coded paths
 find_path(_MAVLINK_INCLUDE_DIR
-    NAMES mavlink/v1.0/mavlink_types.h mavlink/v2.0/mavlink_types.h
-    PATH_SUFFIXES include
+    NAMES mavlink_types.h
+    PATH_SUFFIXES include/mavlink
     PATHS ${_MAVLINK_EXTRA_SEARCH_PATHS}
     NO_CMAKE_PATH
     NO_CMAKE_ENVIRONMENT_PATH

--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -49,7 +49,7 @@
 
 #include <Eigen/Eigen>
 
-#include <mavlink/v2.0/common/mavlink.h>
+#include <common/mavlink.h>
 #include "msgbuffer.h"
 
 static const uint32_t kDefaultMavlinkUdpPort = 14560;

--- a/include/msgbuffer.h
+++ b/include/msgbuffer.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <cassert>
-#include "mavlink/v2.0/common/mavlink.h"
+#include <common/mavlink.h>
 
 /**
  * @brief Message buffer for internal use in libmavconn


### PR DESCRIPTION
 - PX4 now generates the mavlink headers in the build directory