### PR TITLE
Revert rascal model to prevent crash on arming

### DIFF
--- a/include/actuator_plugin.h
+++ b/include/actuator_plugin.h
@@ -50,7 +50,7 @@
 struct ActuatorMap {
   size_t index;
   double scale;
-  string property;
+  std::string property;
 };
 
 class ActuatorPlugin {


### PR DESCRIPTION
**Problem Description**
When trying to fly the Rascal model with PX4 SITL, the vehicle would crash immediately after takeoff

Turns out this was because the motor attached on https://github.com/Auterion/FlightGear-Rascal/commit/d0d1db1961549e557885002cf9c3cff40cc27be2 was way to powerful
@RomanBapst FYI (5 years old commit...)

Fixes https://github.com/PX4/PX4-Autopilot/issues/24466
@simfinite

**Solution**
Revert model to use previous gas powered engine (for now)

![image](https://github.com/user-attachments/assets/3dc9866a-9cf8-48b5-8e40-ce981cc281a6)
