### PR TITLE
fix: include <string> in actuator_plugin.h to avoid build error

### DIFF
--- a/include/actuator_plugin.h
+++ b/include/actuator_plugin.h
@@ -42,7 +42,7 @@
 #pragma once
 
 #include "common.h"
-
+#include <string>
 #include <FGFDMExec.h>
 #include <tinyxml.h>
 #include <Eigen/Eigen>
@@ -50,7 +50,7 @@
 struct ActuatorMap {
   size_t index;
   double scale;
-  string property;
+  std::string property;
 };
 
 class ActuatorPlugin {


### PR DESCRIPTION
The `<string>` header was missing from `actuator_plugin.h`, causing build failures due to use of `std::string`. This PR fixes it by including the header explicitly.

_Tested locally with `make px4_sitl jsbsim` on Ubuntu 22.04._
